### PR TITLE
Added CTRL-W W and CTRL-W CTRL-W mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,11 @@ local cfg = {
 	mappings = {},       -- table containing mappings, see below
 	windownav = {        -- window movement mappings to navigate out of nnn
 		left = "<C-w>h",
-		right = "<C-w>l"
+		right = "<C-w>l",
+		next = "<C-w>w",
+		prev = "<C-w>W",
 	},
-	buflisted = false     -- wether or not nnn buffers show up in the bufferlist
+	buflisted = false,   -- wether or not nnn buffers show up in the bufferlist
 }
 ```
 
@@ -126,7 +128,7 @@ require("nnn").setup({
 		session = "shared",
 	},
 	replace_netrw = "picker",
-	window_nav = "<C-l>"
+	windownav = "<C-l>"
 })
 ```
 

--- a/lua/nnn.lua
+++ b/lua/nnn.lua
@@ -40,7 +40,7 @@ local cfg = {
 	auto_close = false,
 	replace_netrw = nil,
 	mappings = {},
-	windownav = { left = "<C-w>h", right = "<C-w>l" },
+	windownav = { left = "<C-w>h", right = "<C-w>l", next1 = "<C-w>w", next2 = "<C-w><C-w>" },
 	buflisted = false,
 }
 
@@ -192,6 +192,8 @@ local function buffer_setup(mode, tab)
 
 	api.nvim_buf_set_keymap(0, "t", cfg.windownav.left, "<C-\\><C-n><C-w>h", {})
 	api.nvim_buf_set_keymap(0, "t", cfg.windownav.right, "<C-\\><C-n><C-w>l", {})
+	api.nvim_buf_set_keymap(0, "t", cfg.windownav.next1, "<C-\\><C-n><C-w>w", {})
+	api.nvim_buf_set_keymap(0, "t", cfg.windownav.next2, "<C-\\><C-n><C-w><C-w>", {})
 	api.nvim_buf_set_name(0, "nnn"..mode..tab)
 end
 

--- a/lua/nnn.lua
+++ b/lua/nnn.lua
@@ -40,7 +40,7 @@ local cfg = {
 	auto_close = false,
 	replace_netrw = nil,
 	mappings = {},
-	windownav = { left = "<C-w>h", right = "<C-w>l", next1 = "<C-w>w", next2 = "<C-w><C-w>" },
+	windownav = { left = "<C-w>h", right = "<C-w>l", next = "<C-w>w", prev = "<C-w>W" },
 	buflisted = false,
 }
 
@@ -192,8 +192,8 @@ local function buffer_setup(mode, tab)
 
 	api.nvim_buf_set_keymap(0, "t", cfg.windownav.left, "<C-\\><C-n><C-w>h", {})
 	api.nvim_buf_set_keymap(0, "t", cfg.windownav.right, "<C-\\><C-n><C-w>l", {})
-	api.nvim_buf_set_keymap(0, "t", cfg.windownav.next1, "<C-\\><C-n><C-w>w", {})
-	api.nvim_buf_set_keymap(0, "t", cfg.windownav.next2, "<C-\\><C-n><C-w><C-w>", {})
+	api.nvim_buf_set_keymap(0, "t", cfg.windownav.next, "<C-\\><C-n><C-w>w", {})
+	api.nvim_buf_set_keymap(0, "t", cfg.windownav.prev, "<C-\\><C-n><C-w>W", {})
 	api.nvim_buf_set_name(0, "nnn"..mode..tab)
 end
 


### PR DESCRIPTION
Hello again!

I've added support for the default Vim mappings CTRL-W W and CTRL-W CTRL-W that rotates through windows.

See it in action here: https://asciinema.org/a/WK90guj5ILS14LzW8x8d7wroV

I did not update the documentation because I thought it would be best if you took a look at the implementation first. (Btw... The docs contains the old name "window_nav" and it goes up to textwidth=79 instead of 78, is the latter a panvimdoc issue maybe?)

Best regards,
Göran Gustafsson