### PR TITLE
builtin.cd_to_path() spaces in path fix

### DIFF
--- a/lua/nnn.lua
+++ b/lua/nnn.lua
@@ -428,7 +428,8 @@ function M.builtin.copy_to_clipboard(files)
 end
 
 function M.builtin.cd_to_path(files)
-	local dir = files[1]:match(".*/")
+	local dir_escaped = files[1]:match(".*/")
+	local dir = dir_escaped:gsub("\\", "")
 	local read = io.open(dir, "r")
 
 	if read ~= nil then

--- a/lua/nnn.lua
+++ b/lua/nnn.lua
@@ -428,9 +428,8 @@ function M.builtin.copy_to_clipboard(files)
 end
 
 function M.builtin.cd_to_path(files)
-	local dir_escaped = files[1]:match(".*/")
-	local dir = dir_escaped:gsub("\\", "")
-	local read = io.open(dir, "r")
+	local dir = files[1]:match(".*/"):sub(0, -2)
+	local read = io.open(dir:gsub("\\", ""), "r")
 
 	if read ~= nil then
 		io.close(read)


### PR DESCRIPTION
Hello (again 😄)!

I noticed that `builtin.cd_to_path()` does not handle spaces in paths. The variables `files` and `dir` contains the escaped path which one would usually need but `fn.execute("cd "..dir)` can't handle it for some reason so I unescaped the path.

Issue in action here: https://asciinema.org/a/493435

Working after fix: https://asciinema.org/a/493452

Best regards,
Göran Gustafsson