### PR TITLE
Open new window with correct width

### DIFF
--- a/lua/nnn.lua
+++ b/lua/nnn.lua
@@ -90,7 +90,7 @@ local function handle_files(iter)
 		end
 
 		if not empty and not notnnn then -- create new win
-			cmd(oppside..api.nvim_get_option("columns") - cfg.explorer.width.."vsplit")
+			cmd(oppside..api.nvim_get_option("columns") - cfg.explorer.width - 1 .."vsplit")
 			targetwin.win = api.nvim_get_current_win()
 		end
 	end


### PR DESCRIPTION
Hello,

I noticed that explorer.width is not adhered to if you close all windows except NnnExplorer and then open up a file. The one character wide split is not accounted for so the new window is wider than it should be, in other words width of NnnExplorer ends up being 23 instead of 24 etc.

You can see it in action here: https://asciinema.org/a/497318

Best regards,
Göran Gustafsson
