### PR TITLE
Popup window border width compensation

### DIFF
--- a/lua/nnn.lua
+++ b/lua/nnn.lua
@@ -267,13 +267,13 @@ local function get_win_size()
 	local vim_height = api.nvim_get_option("lines")
 	local vim_width = api.nvim_get_option("columns")
 
-	wincfg.height = min(max(0, floor(style.height > 1 and style.height or (vim_height * style.height))), vim_height)
-	wincfg.width = min(max(0, floor(style.width > 1 and style.width or (vim_width * style.width))), vim_width)
+	wincfg.height = min(max(0, floor(style.height > 1 and style.height or (vim_height * style.height))), vim_height) - 1
+	wincfg.width = min(max(0, floor(style.width > 1 and style.width or (vim_width * style.width))), vim_width) - 1
 
-	local row = floor(style.yoffset > 1 and style.yoffset or (style.yoffset * (vim_height - wincfg.height)))
-	local col = floor(style.xoffset > 1 and style.xoffset or (style.xoffset * (vim_width - wincfg.width)))
+	local row = floor(style.yoffset > 1 and style.yoffset or (style.yoffset * (vim_height - wincfg.height))) - 1
+	local col = floor(style.xoffset > 1 and style.xoffset or (style.xoffset * (vim_width - wincfg.width))) - 1
 
-	wincfg.row = min(max(0, row), vim_height - wincfg.height) - 1
+	wincfg.row = min(max(0, row), vim_height - wincfg.height)
 	wincfg.col = min(max(0, col), vim_width - wincfg.width)
 
 	return wincfg


### PR DESCRIPTION
Hello,

I noticed that the size and position of popup windows are slightly off and figured out it is because the 2 character border width is not compensated for. This patch subtract 1 from height, width, row and col.

### Test 1 - Before & After:
<img width="689" alt="pre-0 5" src="https://user-images.githubusercontent.com/595501/172149505-566e979b-d55d-48dc-918f-2dfb2c166e67.png">

<img width="689" alt="post-0 5" src="https://user-images.githubusercontent.com/595501/172149546-4900373b-2816-4f35-8dbc-54afbcc0716b.png">

### Test 2 - Before & After:
<img width="689" alt="pre-split" src="https://user-images.githubusercontent.com/595501/172149567-c69ad4a1-71d6-4e6b-98cb-ba99e5373983.png">

<img width="689" alt="post-split" src="https://user-images.githubusercontent.com/595501/172149571-b06bc851-cc09-4286-aa32-f32fc4217e78.png">


### Reproduce:
Command: `vim -c 'set laststatus=3' -c vsplit -c split -c "wincmd w" -c split`
Terminal window: 81x28 (81x27 with Tmux). All Vim windows must be the exact same size.

Test 1:
```
  picker = {
    style = {
      height = 0.5,
      width = 0.5,
    },
  },
```
Test 2:
```
  picker = {
    style = {
      height = 0.5,
      width = 0.5,
      xoffset = 0,
    },
  },
```

Best regards,
Göran Gustafsson
