### PR TITLE
Hijack e key to prevent nnn.nvim nnn nvim inception

### DIFF
--- a/lua/nnn.lua
+++ b/lua/nnn.lua
@@ -206,6 +206,7 @@ local function buffer_setup(mode, tab)
 		api.nvim_buf_set_keymap(0, "t", mapping[1], "<C-\\><C-n><cmd>lua require('nnn').handle_mapping("..i..")<CR>", {})
 	end
 
+	api.nvim_buf_set_keymap(0, "t", "e", "", {})
 	api.nvim_buf_set_keymap(0, "t", cfg.windownav.left, "<C-\\><C-n><C-w>h", {})
 	api.nvim_buf_set_keymap(0, "t", cfg.windownav.right, "<C-\\><C-n><C-w>l", {})
 	api.nvim_buf_set_keymap(0, "t", cfg.windownav.next, "<C-\\><C-n><C-w>w", {})


### PR DESCRIPTION
Hello!

When running `nnn -p`/`NnnPicker` the "e" (Edit file) key is disabled and that is of course not the case with `nnn`/`NnnExplorer` which can make things end up a bit messy if you are not careful. Worst case scenario is that a user ends up pressing "e" by habit while a directory is selected which will start nvim and then nnn.nvim netrw hijack :exploding_head:

See it in action here:
[https://asciinema.org/a/500370](https://asciinema.org/a/500370)

I've actually ended up doing this a few times because I use both "e" and return open things in nnn. I tried to hijack it on my end with `mappings = {}` first but that doesn't work and I figured others might appreciate it too.

Best regards,
Göran Gustafsson
