### PR TITLE
wip: supports mouse button event in more terminals

### DIFF
--- a/lua/nnn.lua
+++ b/lua/nnn.lua
@@ -299,9 +299,9 @@ local function open(mode, tab, is_dir, empty)
 	local win, buf, new = create_win(mode, tab, is_dir, fs)
 
 	if new then
-		id = f.termopen(cfg[mode].cmd..startdir, {
-			env = (mode == "picker" and { TERM = term } or
-				{ TERM = term, NNN_OPTS = exploreropts, NNN_FIFO = explorertmp }),
+		id = f.termopen("echo '\x1b[?1002h' && " .. cfg[mode].cmd..startdir, {
+			env = (mode == "picker" and nil or
+				{ NNN_OPTS = exploreropts, NNN_FIFO = explorertmp }),
 			on_exit = on_exit,
 			on_stdout = on_stdout,
 			stdout_buffered = true


### PR DESCRIPTION
hi this pr trys to solve the mouse malfunction (no mouse button event being reported) in another way, which works in more terminals which are st, urxvt, kitty, konsole, gnome-terminal. at now it does work in these terminal under the explorer mode.

Though it introduces a weird problem that once NnnExplorer is opened, the opened NnnPicker window will keep losing its focus. another clue I have observed that each time I open NnnPicker, the fifo will receive a new line.
It seems to be a tough problem to me, do you have any quick thoughts on addressing it?