### PR TITLE
feat: add option to disable auto-fullscreen on empty tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ local cfg = {
 		side = "topleft",  -- or "botright", location of the explorer window
 		session = "",      -- or "global" / "local" / "shared"
 		tabs = true,       -- seperate nnn instance per tab
+		fullscreen = true, -- whether to fullscreen explorer window when current tab is empty
 	},
 	picker = {
 		cmd = "nnn",       -- command override (-p flag is implied)
@@ -96,6 +97,7 @@ local cfg = {
 			border = "single"-- border decoration for example "rounded"(:h nvim_open_win)
 		},
 		session = "",      -- or "global" / "local" / "shared"
+		fullscreen = true, -- whether to fullscreen picker window when current tab is empty
 	},
 	auto_open = {
 		setup = nil,       -- or "explorer" / "picker", auto open on setup function

--- a/doc/nnn.txt
+++ b/doc/nnn.txt
@@ -80,6 +80,7 @@ DEFAULT OPTIONS ~
             side = "topleft",  -- or "botright", location of the explorer window
             session = "",      -- or "global" / "local" / "shared"
             tabs = true,       -- seperate nnn instance per tab
+            fullscreen_on_empty = true, -- whether to fullscreen nnn window when tab is empty
         },
         picker = {
             cmd = "nnn",       -- command override (-p flag is implied)
@@ -91,6 +92,7 @@ DEFAULT OPTIONS ~
                 border = "single"-- border decoration for example "rounded"(:h nvim_open_win)
             },
             session = "",      -- or "global" / "local" / "shared"
+            fullscreen_on_empty = true, -- whether to fullscreen nnn window when tab is empty
         },
         auto_open = {
             setup = nil,       -- or "explorer" / "picker", auto open on setup function

--- a/lua/nnn.lua
+++ b/lua/nnn.lua
@@ -28,12 +28,14 @@ local cfg = {
 		width = 24,
 		side = "topleft",
 		session = "",
-		tabs = true
+		tabs = true,
+		fullscreen= true,
 	},
 	picker = {
 		cmd = "nnn",
 		style = { width = 0.9, height = 0.8, xoffset = 0.5, yoffset = 0.5, border = "single" },
 		session = "",
+		fullscreen= true,
 	},
 	auto_open = {
 		setup = nil,
@@ -295,7 +297,7 @@ end
 local function open(mode, tab, is_dir, empty)
 	local id = state[mode][tab] and state[mode][tab].id
 	local curwin = a.nvim_get_current_win()
-	local fs = #a.nvim_tabpage_list_wins(0) == 1 and empty
+	local fs = cfg[mode].fullscreen and #a.nvim_tabpage_list_wins(0) == 1 and empty
 	local win, buf, new = create_win(mode, tab, is_dir, fs)
 
 	if new then


### PR DESCRIPTION
This patch adds the `fullscreen_on_empty` config option in both the `explorer` and `picker` config tables to control whether nnn windows are automatically fullscreened when opened from a tab with a single empty buffer.

Fixes #75 