### PR TITLE
fix: invalid window expected lua number

### DIFF
--- a/lua/nnn.lua
+++ b/lua/nnn.lua
@@ -215,7 +215,7 @@ local function on_exit(id, code)
     end
   end
   -- restore last known active window
-  if targetwin then a.nvim_set_current_win(targetwin.win) end
+  if targetwin.win then a.nvim_set_current_win(targetwin.win) end
 end
 
 -- on_stdout callback for error catching


### PR DESCRIPTION
```sh
.../share/nvim/site/pack/plugins/start/nnn.nvim/lua/nnn.lua:218: Invalid 'window': Expected Lua number
stack traceback:
        [C]: in function 'nvim_set_current_win'
        .../share/nvim/site/pack/plugins/start/nnn.nvim/lua/nnn.lua:218: in function <.../share/nvim/site/pack/plugins/start/nnn.nvim/lua/nnn.lua:178>
```